### PR TITLE
Fix: Hook into `emit` instead of `afterEmit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "author": "wuct <wu.chingting@gmail.com>",
+  "author": "wuct <wu.chingting@gmail.com>, Sebastian Felix Zappe <sebastian@sozialhelden.de>",
   "repository": {
     "type": "git",
     "url": "https://github.com/wuct/elastic-apm-sourcemap-webpack-plugin"

--- a/src/elastic-apm-sourcemap-webpack-plugin.ts
+++ b/src/elastic-apm-sourcemap-webpack-plugin.ts
@@ -32,7 +32,7 @@ export default class ElasticAPMSourceMapPlugin implements webpack.Plugin {
     );
   }
 
-  afterEmit(
+  emit(
     compilation: webpack.compilation.Compilation,
     callback: (error?: Error) => void
   ): Promise<void> {
@@ -116,12 +116,12 @@ export default class ElasticAPMSourceMapPlugin implements webpack.Plugin {
     // We only run tests against Webpack 4 currently.
     /* istanbul ignore next */
     if (compiler.hooks) {
-      compiler.hooks.afterEmit.tapAsync('ElasticAPMSourceMapPlugin', (compilation, callback) =>
-        this.afterEmit(compilation, callback)
+      compiler.hooks.emit.tapAsync('ElasticAPMSourceMapPlugin', (compilation, callback) =>
+        this.emit(compilation, callback)
       );
     } else {
-      compiler.plugin('after-emit', (compilation, callback) =>
-        this.afterEmit(compilation, callback)
+      compiler.plugin('emit', (compilation, callback) =>
+        this.emit(compilation, callback)
       );
     }
   }


### PR DESCRIPTION
Thanks for your work on this plugin!

Webpack 5+ will not allow access to the sources of an asset after it has been emitted (to save memory while building), as visible here: https://github.com/webpack/webpack/commit/aaf85dbd1c221eb1788dd46894d24ebd9c62aa62

The new webpack logic breaks this plugin, as it assumes the source is still accessible at the `afterEmit` stage, resulting in an exception while uploading (`”Content and Map of this Source is no longer available (only size() is supported)”`) when using webpack 5. I'm using Next.js, so I stumbled upon this issue.

As a fix, the code in this PR uses the `emit` instead of the `afterEmit` hook. After this fix, my assets seem to be uploaded correctly again.

I've never developed Webpack plugins before – could you confirm this works as supposed? :)