### PR TITLE
test: add output.futureEmitAssets

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -17,7 +17,11 @@ jest.mock('webpack-log', () => {
 const getWebpackConfig = (pluginConfig: Config): webpack.Configuration => ({
   entry: path.resolve(__dirname, './entry.js'),
   devtool: 'source-map',
-  plugins: [new ElasticAPMSourceMapPlugin(pluginConfig)]
+  plugins: [new ElasticAPMSourceMapPlugin(pluginConfig)],
+  // TODO: remove this after Webpack 5
+  output: {
+    futureEmitAssets: true
+  }
 });
 
 beforeEach(() => {


### PR DESCRIPTION
output.futureEmitAssets will be default in Webpack 5. Add this for testing to ensure the
compatibility of Webpack 5.