### PR TITLE
Assume sourcemap name if blank

### DIFF
--- a/src/elastic-apm-sourcemap-webpack-plugin.ts
+++ b/src/elastic-apm-sourcemap-webpack-plugin.ts
@@ -63,7 +63,10 @@ export default class ElasticAPMSourceMapPlugin implements webpack.Plugin {
           }),
       R.map(({ sourceFile, sourceMap }) => {
         /* istanbul ignore next */
-        if (!sourceFile || !sourceMap) {
+        if (sourceFile && !sourceMap) {
+          // Assume the sourcemap's name if the value is blank
+          sourceMap = sourceFile + '.map'
+        } else if (!sourceFile || !sourceMap) {
           // It is impossible for Wepback to run into here.
           logger.debug('there is no .js files to be uploaded.');
           return Promise.resolve();


### PR DESCRIPTION
I was using this successfully on webpack 3 but it fails after upgrading to webpack 5 with the following error, written multiple times:
```
⬡ ElasticAPMSourceMapPlugin: there is no .js files to be uploaded.
```

I determined the sourceFile was populated but the sourceMap was blank. I'm sure there is a correct way to do this with webpack 5 but this is a nice cheap solution. 🙂 